### PR TITLE
[18.0][IMP] quality_control_stock_oca: per-lot/serial inspections

### DIFF
--- a/quality_control_stock_oca/README.rst
+++ b/quality_control_stock_oca/README.rst
@@ -31,7 +31,9 @@ Quality control - Stock (OCA)
 This module defines triggers that creates inspections when stock moves
 are done.
 
-It also adds some shortcuts on picking and lots to these inspections.
+It also adds some shortcuts on picking and lots to these inspections. It
+supports generating one inspection per lot or serial number when the
+trigger is configured accordingly.
 
 **Table of contents**
 
@@ -41,7 +43,7 @@ It also adds some shortcuts on picking and lots to these inspections.
 Known issues / Roadmap
 ======================
 
--  Put trigger in all languages.
+- Put trigger in all languages.
 
 Bug Tracker
 ===========
@@ -66,19 +68,19 @@ Authors
 Contributors
 ------------
 
--  Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>
--  Simone Rubino <simone.rubino@agilebg.com>
--  Andrii Skrypka <andrijskrypa@ukr.net>
--  Ignacio José Alés <ignacio.ales@guadaltech.es>
--  Pimolnat Suntian <pimolnats@ecosoft.co.th>
--  `Tecnativa <https://www.tecnativa.com>`__:
+- Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>
+- Simone Rubino <simone.rubino@agilebg.com>
+- Andrii Skrypka <andrijskrypa@ukr.net>
+- Ignacio José Alés <ignacio.ales@guadaltech.es>
+- Pimolnat Suntian <pimolnats@ecosoft.co.th>
+- `Tecnativa <https://www.tecnativa.com>`__:
 
-   -  Pedro M. Baeza
-   -  Carlos Roca
+  - Pedro M. Baeza
+  - Carlos Roca
 
--  `APSL-Nagarro <https://www.apsl.tech>`__:
+- `APSL-Nagarro <https://www.apsl.tech>`__:
 
-   -  Antoni Marroig <amarroig@apsl.net>
+  - Antoni Marroig <amarroig@apsl.net>
 
 Maintainers
 -----------

--- a/quality_control_stock_oca/__manifest__.py
+++ b/quality_control_stock_oca/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     "name": "Quality control - Stock (OCA)",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.1.0",
     "category": "Quality control",
     "license": "AGPL-3",
     "author": "Tecnativa, AvanzOSC, "

--- a/quality_control_stock_oca/i18n/quality_control_stock_oca.pot
+++ b/quality_control_stock_oca/i18n/quality_control_stock_oca.pot
@@ -86,11 +86,6 @@ msgid "Inspection per lot/serial"
 msgstr ""
 
 #. module: quality_control_stock_oca
-#: model:ir.model.fields,field_description:quality_control_stock_oca.field_qc_inspection__lot_name
-msgid "Lot Name"
-msgstr ""
-
-#. module: quality_control_stock_oca
 #: model:ir.model,name:quality_control_stock_oca.model_qc_inspection
 msgid "Quality control inspection"
 msgstr ""

--- a/quality_control_stock_oca/i18n/quality_control_stock_oca.pot
+++ b/quality_control_stock_oca/i18n/quality_control_stock_oca.pot
@@ -81,6 +81,16 @@ msgid "Picking Type"
 msgstr ""
 
 #. module: quality_control_stock_oca
+#: model:ir.model.fields,field_description:quality_control_stock_oca.field_qc_trigger__per_lot
+msgid "Inspection per lot/serial"
+msgstr ""
+
+#. module: quality_control_stock_oca
+#: model:ir.model.fields,field_description:quality_control_stock_oca.field_qc_inspection__lot_name
+msgid "Lot Name"
+msgstr ""
+
+#. module: quality_control_stock_oca
 #: model:ir.model,name:quality_control_stock_oca.model_qc_inspection
 msgid "Quality control inspection"
 msgstr ""

--- a/quality_control_stock_oca/migrations/18.0.1.1.0/pre-migration.py
+++ b/quality_control_stock_oca/migrations/18.0.1.1.0/pre-migration.py
@@ -1,9 +1,0 @@
-from openupgradelib import openupgrade
-
-
-@openupgrade.migrate()
-def migrate(env, version):
-    openupgrade.logged_query(
-        env.cr,
-        "ALTER TABLE qc_inspection ADD COLUMN IF NOT EXISTS lot_name varchar",
-    )

--- a/quality_control_stock_oca/migrations/18.0.1.1.0/pre-migration.py
+++ b/quality_control_stock_oca/migrations/18.0.1.1.0/pre-migration.py
@@ -1,9 +1,9 @@
 from openupgradelib import openupgrade
 
+
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.logged_query(
         env.cr,
         "ALTER TABLE qc_inspection ADD COLUMN IF NOT EXISTS lot_name varchar",
     )
-

--- a/quality_control_stock_oca/migrations/18.0.1.1.0/pre-migration.py
+++ b/quality_control_stock_oca/migrations/18.0.1.1.0/pre-migration.py
@@ -1,0 +1,9 @@
+from openupgradelib import openupgrade
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.logged_query(
+        env.cr,
+        "ALTER TABLE qc_inspection ADD COLUMN IF NOT EXISTS lot_name varchar",
+    )
+

--- a/quality_control_stock_oca/models/qc_inspection.py
+++ b/quality_control_stock_oca/models/qc_inspection.py
@@ -85,13 +85,19 @@ class QcInspection(models.Model):
             res["qty"] = object_ref.product_uom_qty
         return res
 
-    def _inspection_exists_per_lot(self, picking, trigger, product, lot_id):
+    def _inspection_exists_per_lot(self, picking, product, lot, trigger_line):
+        test_rec = getattr(
+            trigger_line, "test_id", getattr(trigger_line, "test", False)
+        )
+
         domain = [
             ("picking_id", "=", picking.id),
-            ("trigger_id", "=", trigger.id),
             ("product_id", "=", product.id),
-            ("lot_id", "=", lot_id),
+            ("lot_id", "=", lot.id),
         ]
+        if test_rec:
+            domain.append(("test", "=", getattr(test_rec, "id", test_rec)))
+
         return bool(self.search_count(domain))
 
     def _make_inspection(self, object_ref, trigger_line):
@@ -113,25 +119,29 @@ class QcInspection(models.Model):
                     continue
                 lot = ml.lot_id
                 qty = done_qty or planned_qty
-                groups.setdefault(lot.id, {"lot_id": lot.id, "qty": 0})
+                groups.setdefault(lot.id, {"lot": lot, "qty": 0})
                 groups[lot.id]["qty"] += qty
             inspections = self.browse()
             for data in groups.values():
                 if self._inspection_exists_per_lot(
                     picking,
-                    trigger,
                     product,
-                    data["lot_id"],
+                    data["lot"],
+                    trigger_line,
                 ):
                     continue
                 inspection = super()._make_inspection(picking, trigger_line)
-                inspection.write(
-                    {
-                        "product_id": product.id,
-                        "qty": data["qty"],
-                        "lot_id": data["lot_id"],
-                    }
+                test_rec = getattr(
+                    trigger_line, "test_id", getattr(trigger_line, "test", False)
                 )
+                vals = {
+                    "product_id": product.id,
+                    "qty": data["qty"],
+                    "lot_id": data["lot"].id,
+                }
+                if test_rec:
+                    vals["test"] = getattr(test_rec, "id", test_rec)
+                inspection.write(vals)
                 inspections |= inspection
             return inspections
         return super()._make_inspection(object_ref, trigger_line)

--- a/quality_control_stock_oca/models/qc_inspection.py
+++ b/quality_control_stock_oca/models/qc_inspection.py
@@ -86,13 +86,12 @@ class QcInspection(models.Model):
         return res
 
     def _inspection_exists_per_lot(self, picking, trigger, product, lot_id):
-        field_trigger = "trigger_id" if "trigger_id" in self._fields else "trigger"
         domain = [
             ("picking_id", "=", picking.id),
-            (field_trigger, "=", trigger.id),
+            ("trigger_id", "=", trigger.id),
             ("product_id", "=", product.id),
+            ("lot_id", "=", lot_id),
         ]
-        domain.append(("lot_id", "=", lot_id))
         return bool(self.search_count(domain))
 
     def _make_inspection(self, object_ref, trigger_line):

--- a/quality_control_stock_oca/models/qc_inspection.py
+++ b/quality_control_stock_oca/models/qc_inspection.py
@@ -6,6 +6,14 @@ from odoo import api, fields, models
 from odoo.fields import first
 
 
+def _done_qty(ml):
+    return getattr(ml, "qty_done", getattr(ml, "quantity", 0.0))
+
+
+def _planned_qty(ml):
+    return getattr(ml, "product_uom_qty", 0.0)
+
+
 class QcInspection(models.Model):
     _inherit = "qc.inspection"
 
@@ -97,15 +105,17 @@ class QcInspection(models.Model):
             product = object_ref.product_id
             picking = object_ref.picking_id
             groups = {}
-            for ml in picking.move_line_ids.filtered(
-                lambda line: line.product_id == product
-                and (line.qty_done or line.product_uom_qty)
-            ):
-                lot = ml.lot_id
-                if not lot:
+            for ml in picking.move_line_ids:
+                if ml.product_id != product:
                     continue
+                done_qty = _done_qty(ml)
+                planned_qty = _planned_qty(ml)
+                if not ml.lot_id or not (done_qty or planned_qty):
+                    continue
+                lot = ml.lot_id
+                qty = done_qty or planned_qty
                 groups.setdefault(lot.id, {"lot_id": lot.id, "qty": 0})
-                groups[lot.id]["qty"] += ml.qty_done or ml.product_uom_qty
+                groups[lot.id]["qty"] += qty
             inspections = self.browse()
             for data in groups.values():
                 if self._inspection_exists_per_lot(

--- a/quality_control_stock_oca/models/qc_inspection.py
+++ b/quality_control_stock_oca/models/qc_inspection.py
@@ -15,7 +15,6 @@ class QcInspection(models.Model):
     lot_id = fields.Many2one(
         comodel_name="stock.lot", compute="_compute_lot", store=True
     )
-    lot_name = fields.Char()
 
     def object_selection_values(self):
         result = super().object_selection_values()
@@ -78,19 +77,14 @@ class QcInspection(models.Model):
             res["qty"] = object_ref.product_uom_qty
         return res
 
-    def _inspection_exists_per_lot(
-        self, picking, trigger, product, lot_id=False, lot_name=False
-    ):
+    def _inspection_exists_per_lot(self, picking, trigger, product, lot_id):
         field_trigger = "trigger_id" if "trigger_id" in self._fields else "trigger"
         domain = [
             ("picking_id", "=", picking.id),
             (field_trigger, "=", trigger.id),
             ("product_id", "=", product.id),
         ]
-        if lot_id:
-            domain.append(("lot_id", "=", lot_id))
-        else:
-            domain.append(("lot_name", "=", lot_name))
+        domain.append(("lot_id", "=", lot_id))
         return bool(self.search_count(domain))
 
     def _make_inspection(self, object_ref, trigger_line):
@@ -107,26 +101,18 @@ class QcInspection(models.Model):
                 lambda line: line.product_id == product
                 and (line.qty_done or line.product_uom_qty)
             ):
-                key = ml.lot_id.id or ml.lot_name
-                if not key:
+                lot = ml.lot_id
+                if not lot:
                     continue
-                groups.setdefault(
-                    key,
-                    {
-                        "lot_id": ml.lot_id.id,
-                        "lot_name": ml.lot_name,
-                        "qty": 0,
-                    },
-                )
-                groups[key]["qty"] += ml.qty_done or ml.product_uom_qty
+                groups.setdefault(lot.id, {"lot_id": lot.id, "qty": 0})
+                groups[lot.id]["qty"] += ml.qty_done or ml.product_uom_qty
             inspections = self.browse()
             for data in groups.values():
                 if self._inspection_exists_per_lot(
                     picking,
                     trigger,
                     product,
-                    lot_id=data["lot_id"],
-                    lot_name=data["lot_name"],
+                    data["lot_id"],
                 ):
                     continue
                 inspection = super()._make_inspection(picking, trigger_line)
@@ -135,7 +121,6 @@ class QcInspection(models.Model):
                         "product_id": product.id,
                         "qty": data["qty"],
                         "lot_id": data["lot_id"],
-                        "lot_name": data["lot_name"] if not data["lot_id"] else False,
                     }
                 )
                 inspections |= inspection

--- a/quality_control_stock_oca/models/qc_inspection.py
+++ b/quality_control_stock_oca/models/qc_inspection.py
@@ -15,6 +15,7 @@ class QcInspection(models.Model):
     lot_id = fields.Many2one(
         comodel_name="stock.lot", compute="_compute_lot", store=True
     )
+    lot_name = fields.Char()
 
     def object_selection_values(self):
         result = super().object_selection_values()
@@ -76,6 +77,70 @@ class QcInspection(models.Model):
         if object_ref and object_ref._name == "stock.move":
             res["qty"] = object_ref.product_uom_qty
         return res
+
+    def _inspection_exists_per_lot(
+        self, picking, trigger, product, lot_id=False, lot_name=False
+    ):
+        field_trigger = "trigger_id" if "trigger_id" in self._fields else "trigger"
+        domain = [
+            ("picking_id", "=", picking.id),
+            (field_trigger, "=", trigger.id),
+            ("product_id", "=", product.id),
+        ]
+        if lot_id:
+            domain.append(("lot_id", "=", lot_id))
+        else:
+            domain.append(("lot_name", "=", lot_name))
+        return bool(self.search_count(domain))
+
+    def _make_inspection(self, object_ref, trigger_line):
+        trigger = trigger_line.trigger
+        if (
+            trigger.per_lot
+            and object_ref._name == "stock.move"
+            and object_ref.product_id.tracking in ("serial", "lot")
+        ):
+            product = object_ref.product_id
+            picking = object_ref.picking_id
+            groups = {}
+            for ml in picking.move_line_ids.filtered(
+                lambda line: line.product_id == product
+                and (line.qty_done or line.product_uom_qty)
+            ):
+                key = ml.lot_id.id or ml.lot_name
+                if not key:
+                    continue
+                groups.setdefault(
+                    key,
+                    {
+                        "lot_id": ml.lot_id.id,
+                        "lot_name": ml.lot_name,
+                        "qty": 0,
+                    },
+                )
+                groups[key]["qty"] += ml.qty_done or ml.product_uom_qty
+            inspections = self.browse()
+            for data in groups.values():
+                if self._inspection_exists_per_lot(
+                    picking,
+                    trigger,
+                    product,
+                    lot_id=data["lot_id"],
+                    lot_name=data["lot_name"],
+                ):
+                    continue
+                inspection = super()._make_inspection(picking, trigger_line)
+                inspection.write(
+                    {
+                        "product_id": product.id,
+                        "qty": data["qty"],
+                        "lot_id": data["lot_id"],
+                        "lot_name": data["lot_name"] if not data["lot_id"] else False,
+                    }
+                )
+                inspections |= inspection
+            return inspections
+        return super()._make_inspection(object_ref, trigger_line)
 
 
 class QcInspectionLine(models.Model):

--- a/quality_control_stock_oca/models/qc_trigger.py
+++ b/quality_control_stock_oca/models/qc_trigger.py
@@ -11,3 +11,4 @@ class QcTrigger(models.Model):
     picking_type_id = fields.Many2one(
         comodel_name="stock.picking.type", ondelete="cascade"
     )
+    per_lot = fields.Boolean("Inspection per lot/serial", default=False)

--- a/quality_control_stock_oca/readme/CHANGELOG.md
+++ b/quality_control_stock_oca/readme/CHANGELOG.md
@@ -1,0 +1,7 @@
+Changelog
+=========
+
+18.0.1.1.0 (2025-08-25)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* [IMP] Allow per-lot/serial quality inspections.

--- a/quality_control_stock_oca/readme/DESCRIPTION.md
+++ b/quality_control_stock_oca/readme/DESCRIPTION.md
@@ -2,3 +2,5 @@ This module defines triggers that creates inspections when stock moves
 are done.
 
 It also adds some shortcuts on picking and lots to these inspections.
+It supports generating one inspection per lot or serial number when the
+trigger is configured accordingly.

--- a/quality_control_stock_oca/static/description/index.html
+++ b/quality_control_stock_oca/static/description/index.html
@@ -372,7 +372,9 @@ ul.auto-toc {
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/manufacture/tree/18.0/quality_control_stock_oca"><img alt="OCA/manufacture" src="https://img.shields.io/badge/github-OCA%2Fmanufacture-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/manufacture-18-0/manufacture-18-0-quality_control_stock_oca"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/manufacture&amp;target_branch=18.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>This module defines triggers that creates inspections when stock moves
 are done.</p>
-<p>It also adds some shortcuts on picking and lots to these inspections.</p>
+<p>It also adds some shortcuts on picking and lots to these inspections. It
+supports generating one inspection per lot or serial number when the
+trigger is configured accordingly.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">

--- a/quality_control_stock_oca/tests/test_quality_control_stock.py
+++ b/quality_control_stock_oca/tests/test_quality_control_stock.py
@@ -317,3 +317,141 @@ class TestQualityControlStockOca(TestQualityControlOcaBase):
         self.inspection1.onchange_object_id()
         self.assertEqual(self.inspection1.lot_id, self.lot)
         self.assertEqual(self.inspection1.product_id, self.lot.product_id)
+
+    def _create_serial_picking(self, serials, per_lot=False, before=False):
+        self.trigger.per_lot = per_lot
+        if before:
+            self.trigger.timing = "before"
+        else:
+            self.trigger.timing = "after"
+        self.product.tracking = "serial"
+        lots = [
+            self.env["stock.lot"].create({"name": sn, "product_id": self.product.id})
+            for sn in serials
+        ]
+        for lot in lots:
+            self.env["stock.quant"].create(
+                {
+                    "product_id": self.product.id,
+                    "location_id": self.location.id,
+                    "quantity": 1,
+                    "lot_id": lot.id,
+                }
+            )
+        picking_form = Form(
+            self.env["stock.picking"]
+            .with_user(self.user)
+            .with_context(default_picking_type_id=self.picking_type.id)
+        )
+        picking_form.partner_id = self.partner1
+        with picking_form.move_ids_without_package.new() as move_form:
+            move_form.product_id = self.product
+            move_form.product_uom_qty = len(serials)
+        picking = picking_form.save()
+        picking.action_confirm()
+        move = picking.move_ids[0]
+        move.move_line_ids.unlink()
+        for lot in lots:
+            self.env["stock.move.line"].create(
+                {
+                    "move_id": move.id,
+                    "product_id": self.product.id,
+                    "qty_done": 1,
+                    "location_id": self.location.id,
+                    "location_dest_id": self.location_dest.id,
+                    "lot_id": lot.id,
+                }
+            )
+        self.product.qc_triggers = [
+            (0, 0, {"trigger": self.trigger.id, "test": self.test.id})
+        ]
+        picking._action_done()
+        return picking
+
+    def test_serial_single_inspection(self):
+        picking = self._create_serial_picking(["sn1", "sn2", "sn3"], per_lot=False)
+        self.assertEqual(picking.created_inspections, 1)
+
+    def test_serial_after_per_lot(self):
+        picking = self._create_serial_picking(["sn1", "sn2", "sn3"], per_lot=True)
+        self.assertEqual(picking.created_inspections, 3)
+
+    def test_serial_before_per_lot(self):
+        picking = self._create_serial_picking(
+            ["sn1", "sn2", "sn3"], per_lot=True, before=True
+        )
+        self.assertEqual(picking.created_inspections, 3)
+
+    def test_lot_per_lot(self):
+        self.trigger.per_lot = True
+        self.product.tracking = "lot"
+        lots = [
+            self.env["stock.lot"].create(
+                {"name": f"lot{i}", "product_id": self.product.id}
+            )
+            for i in range(1, 3)
+        ]
+        for lot in lots:
+            self.env["stock.quant"].create(
+                {
+                    "product_id": self.product.id,
+                    "location_id": self.location.id,
+                    "quantity": 1,
+                    "lot_id": lot.id,
+                }
+            )
+        picking_form = Form(
+            self.env["stock.picking"]
+            .with_user(self.user)
+            .with_context(default_picking_type_id=self.picking_type.id)
+        )
+        picking_form.partner_id = self.partner1
+        with picking_form.move_ids_without_package.new() as move_form:
+            move_form.product_id = self.product
+            move_form.product_uom_qty = 2
+        picking = picking_form.save()
+        picking.action_confirm()
+        move = picking.move_ids[0]
+        move.move_line_ids.unlink()
+        for lot in lots:
+            self.env["stock.move.line"].create(
+                {
+                    "move_id": move.id,
+                    "product_id": self.product.id,
+                    "qty_done": 1,
+                    "location_id": self.location.id,
+                    "location_dest_id": self.location_dest.id,
+                    "lot_id": lot.id,
+                }
+            )
+        self.product.qc_triggers = [
+            (0, 0, {"trigger": self.trigger.id, "test": self.test.id})
+        ]
+        picking._action_done()
+        self.assertEqual(picking.created_inspections, 2)
+
+    def test_no_tracking_per_lot(self):
+        self.trigger.per_lot = True
+        self.product.tracking = "none"
+        picking_form = Form(
+            self.env["stock.picking"]
+            .with_user(self.user)
+            .with_context(default_picking_type_id=self.picking_type.id)
+        )
+        picking_form.partner_id = self.partner1
+        with picking_form.move_ids_without_package.new() as move_form:
+            move_form.product_id = self.product
+            move_form.product_uom_qty = 3
+        picking = picking_form.save()
+        picking.action_confirm()
+        self.product.qc_triggers = [
+            (0, 0, {"trigger": self.trigger.id, "test": self.test.id})
+        ]
+        picking._action_done()
+        self.assertEqual(picking.created_inspections, 1)
+
+    def test_duplicate_inspection_prevention(self):
+        picking = self._create_serial_picking(["sn1"], per_lot=True)
+        initial = picking.created_inspections
+        picking._action_done()
+        self.assertEqual(picking.created_inspections, initial)

--- a/quality_control_stock_oca/views/qc_trigger_view.xml
+++ b/quality_control_stock_oca/views/qc_trigger_view.xml
@@ -8,6 +8,9 @@
             <xpath expr="//field[@name='partner_selectable']" position="after">
                 <field name="picking_type_id" readonly="1" />
             </xpath>
+            <xpath expr="//field[@name='picking_type_id']" position="after">
+                <field name="per_lot" />
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
## Summary
- add per-lot/serial option on quality control trigger
- generate dedicated inspections per lot/serial and avoid duplicates
- document the new behaviour

## Testing
- `pre-commit run --all-files`
- `pytest quality_control_stock_oca/tests/test_quality_control_stock.py` *(fails: No module named 'odoo')*


------
https://chatgpt.com/codex/tasks/task_e_68ac75440dc4832ca1bbfdb473351248